### PR TITLE
feat: Add debug helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,16 @@ At the moment, only parts of the `ServiceConfig` struct are returned. The missin
 - `ready_conditions`
 - `image` field currently only returns the image name, not the build spec
 
+#### `kurtestosis.debug(value)`
+
+An equivalent of `print` in pure starlark, useful for debugging `kurtestosis` tests.
+
+```python
+def test_get_service_config(plan):
+    kurtestosis.debug("some value")
+    kurtestosis.debug(value = "some value")
+```
+
 ## Development
 
 ### Development environment

--- a/cli/kurtosis/modules/builtins/debug.go
+++ b/cli/kurtosis/modules/builtins/debug.go
@@ -1,0 +1,49 @@
+package builtins
+
+import (
+	"github.com/kurtosis-tech/kurtosis/core/server/api_container/server/startosis_engine/kurtosis_starlark_framework"
+	"github.com/kurtosis-tech/kurtosis/core/server/api_container/server/startosis_engine/kurtosis_starlark_framework/builtin_argument"
+	"github.com/kurtosis-tech/kurtosis/core/server/api_container/server/startosis_engine/kurtosis_starlark_framework/kurtosis_helper"
+	"github.com/kurtosis-tech/kurtosis/core/server/api_container/server/startosis_engine/startosis_errors"
+	"github.com/sirupsen/logrus"
+	"go.starlark.net/starlark"
+)
+
+const (
+	DebugBuiltinName = "debug"
+
+	DebugBuiltinValueArgName = "value"
+)
+
+func NewDebug() *kurtosis_helper.KurtosisHelper {
+	return &kurtosis_helper.KurtosisHelper{
+		KurtosisBaseBuiltin: &kurtosis_starlark_framework.KurtosisBaseBuiltin{
+			Name: DebugBuiltinName,
+			Arguments: []*builtin_argument.BuiltinArgument{
+				{
+					Name:              DebugBuiltinValueArgName,
+					IsOptional:        false,
+					ZeroValueProvider: builtin_argument.ZeroValueProvider[starlark.Value],
+					Validator: func(value starlark.Value) *startosis_errors.InterpretationError {
+						return nil
+					},
+				},
+			},
+		},
+
+		Capabilities: &debugCapabilities{},
+	}
+}
+
+type debugCapabilities struct{}
+
+func (builtin *debugCapabilities) Interpret(locatorOfModuleInWhichThisBuiltInIsBeingCalled string, arguments *builtin_argument.ArgumentValuesSet) (starlark.Value, *startosis_errors.InterpretationError) {
+	valueArg, err := builtin_argument.ExtractArgumentValue[starlark.Value](arguments, DebugBuiltinValueArgName)
+	if err != nil {
+		return nil, startosis_errors.WrapWithInterpretationError(err, "An error occurred while extracting the value argument for debug builtin")
+	}
+
+	logrus.Infof("%s: %s", locatorOfModuleInWhichThisBuiltInIsBeingCalled, valueArg)
+
+	return starlark.None, nil
+}

--- a/cli/kurtosis/modules/kurtestosis.go
+++ b/cli/kurtosis/modules/kurtestosis.go
@@ -26,6 +26,7 @@ func LoadKurtestosisModule(interpretationTimeValueStore *interpretation_time_val
 		"__before_test__":                    starlark.NewBuiltin("__before_test__", runBeforeTest),
 		"__after_test__":                     starlark.NewBuiltin("__after_test__", runAfterTest),
 		builtins.GetServiceConfigBuiltinName: starlark.NewBuiltin(builtins.GetServiceConfigBuiltinName, builtins.NewGetServiceConfig(interpretationTimeValueStore).CreateBuiltin()),
+		builtins.DebugBuiltinName:            starlark.NewBuiltin(builtins.DebugBuiltinName, builtins.NewDebug().CreateBuiltin()),
 	}
 	thread := new(starlark.Thread)
 

--- a/cli/kurtosis/modules/kurtestosis.star
+++ b/cli/kurtosis/modules/kurtestosis.star
@@ -22,6 +22,10 @@ def test(plan, mod, fn_name):
 kurtestosis = module(
     "kurtestosis",
     test = test,
-    # get_service_config is defined as a global builtin included when this file is processed
+    # 
+    # These are defined as global builtins when loading this module,
+    # we just re-export them under the kurtestosis namespace
+    # 
     get_service_config = get_service_config,
+    debug = debug,
 )

--- a/test/project--passing/debug_test.star
+++ b/test/project--passing/debug_test.star
@@ -1,0 +1,9 @@
+def test_debug(plan):
+    kurtestosis.debug(struct())
+    kurtestosis.debug(value = struct())
+    kurtestosis.debug(value = {
+        "some": "dict"
+    })
+
+    # This will produce a warning as function pointers cannot be copied
+    kurtestosis.debug(value = plan.run_sh)


### PR DESCRIPTION
<!--
Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**

Adds a `debug` helper to `kurtestosis` module for printing stuff (since `print` is shadowed by `kurtosis`)